### PR TITLE
Fix inital put bug

### DIFF
--- a/lume_epics/client/controller.py
+++ b/lume_epics/client/controller.py
@@ -60,7 +60,7 @@ class Controller:
 
     """
 
-    def __init__(self, protocol: str):
+    def __init__(self, protocol: str, return_default: bool = False):
         """
         Initializes controller. Stores protocol and creates context attribute if 
         using pvAccess.
@@ -69,9 +69,13 @@ class Controller:
             protocol (str): Protocol for getting values from variables ("pva" for pvAccess, "ca" for
             Channel Access)
 
+            return_default (bool): Whether to return available variable default rather than default. Will use
+            global default if the variable default is not found.
+
         """
         self.protocol = protocol
         self.pv_registry = defaultdict()
+        self._return_default = return_default
 
         # initalize context for pva
         self.context = None
@@ -237,11 +241,17 @@ class Controller:
 
         """
         self.setup_pv_monitor(pvname)
-        if self.protocol == "ca":
-            self.pv_registry[pvname]["pv"].put(value, timeout=timeout)
+        
+        # allow no puts before a value has been collected
+        registered = self.get(pvname)
 
-        elif self.protocol == "pva":
-            self.context.put(pvname, value, throw=False, timeout=timeout)
+        # if the value is registered
+        if registered is not None:
+            if self.protocol == "ca":
+                self.pv_registry[pvname]["pv"].put(value, timeout=timeout)
+
+            elif self.protocol == "pva":
+                self.context.put(pvname, value, throw=False, timeout=timeout)
 
     def close(self):
         if self.protocol == "pva":

--- a/lume_epics/client/controller.py
+++ b/lume_epics/client/controller.py
@@ -60,7 +60,7 @@ class Controller:
 
     """
 
-    def __init__(self, protocol: str, return_default: bool = False):
+    def __init__(self, protocol: str):
         """
         Initializes controller. Stores protocol and creates context attribute if 
         using pvAccess.
@@ -69,13 +69,9 @@ class Controller:
             protocol (str): Protocol for getting values from variables ("pva" for pvAccess, "ca" for
             Channel Access)
 
-            return_default (bool): Whether to return available variable default rather than default. Will use
-            global default if the variable default is not found.
-
         """
         self.protocol = protocol
         self.pv_registry = defaultdict()
-        self._return_default = return_default
 
         # initalize context for pva
         self.context = None
@@ -241,9 +237,6 @@ class Controller:
 
         """
         self.setup_pv_monitor(pvname)
-        
-        # allow no puts before a value has been collected
-        registered = self.get(pvname)
 
         # if the value is registered
         if registered is not None:
@@ -252,6 +245,9 @@ class Controller:
 
             elif self.protocol == "pva":
                 self.context.put(pvname, value, throw=False, timeout=timeout)
+
+        else:
+            logger.debug(f"No initial value set for {pvname}.")
 
     def close(self):
         if self.protocol == "pva":


### PR DESCRIPTION
Confirm initial value collection before allowing put. Preemptive client rendering introduced a bug where the defaults were submitted to the client before receiving values.