### PR TITLE
BUG: Fix protocol passing to server

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -5,11 +5,12 @@ from lume_model.utils import variables_from_yaml
 with open("examples/files/demo_config.yml", "r") as f:
     input_variables, output_variables = variables_from_yaml(f)
 
-model = DemoModel(input_variables=input_variables, output_variables=output_variables)
 prefix = "test"
 server = Server(
-    model,
+    DemoModel,
     prefix,
+    model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
+    protocols=["pva"]
 )
 # monitor = False does not loop in main thread
 server.start(monitor=True)

--- a/lume_epics/commands/serve_from_template.py
+++ b/lume_epics/commands/serve_from_template.py
@@ -24,7 +24,8 @@ def serve_from_template(filename, prefix, serve_ca, serve_pva):
     server = Server(
         model_class,
         prefix,
-        model_kwargs=model_kwargs
+        model_kwargs=model_kwargs,
+        protocols = protocols
     )
 
     server.start(monitor=True)

--- a/lume_epics/epics_server.py
+++ b/lume_epics/epics_server.py
@@ -113,20 +113,23 @@ class Server:
             }
         )
 
-        self.ca_process = CAServer(
-            prefix=self.prefix,
-            input_variables=self.input_variables,
-            output_variables=self.output_variables,
-            in_queue=self.in_queue,
-            out_queue=self.out_queues["ca"]
-        )
-        self.pva_process = PVAServer(
-            prefix=self.prefix,
-            input_variables=self.input_variables,
-            output_variables=self.output_variables,
-            in_queue=self.in_queue,
-            out_queue=self.out_queues["pva"]
-        )
+        if "ca" in protocols:
+            self.ca_process = CAServer(
+                prefix=self.prefix,
+                input_variables=self.input_variables,
+                output_variables=self.output_variables,
+                in_queue=self.in_queue,
+                out_queue=self.out_queues["ca"]
+            )
+
+        if "pva" in protocols:
+            self.pva_process = PVAServer(
+                prefix=self.prefix,
+                input_variables=self.input_variables,
+                output_variables=self.output_variables,
+                in_queue=self.in_queue,
+                out_queue=self.out_queues["pva"]
+            )
 
     def run_comm_thread(self, model_class, model_kwargs={}, in_queue: multiprocessing.Queue=None,
                         out_queues: Dict[str, multiprocessing.Queue]=None):
@@ -177,7 +180,7 @@ class Server:
         Args: 
             monitor (bool): Indicates whether to run the server in the background
                 or to continually monitor. If monitor = False, the server must be
-                explicitely stopped using server.stop()
+                explicitly stopped using server.stop()
 
         """
         self.comm_thread.start()


### PR DESCRIPTION
This PR fixes a bug that involved passing the optional disabling of protocols in serve-from-template and the optional initialization of the servers in the event of a single protocol server.