### PR TITLE
BUG: Fixes for controller and server bugs

### DIFF
--- a/docs/Widgets_doc.md
+++ b/docs/Widgets_doc.md
@@ -6,7 +6,7 @@ All widgets accept a `lume-epics` controller, a prefix, and a`lume-model` variab
 
 ## Control widgets
 
-These widgets are used for manipulating process variable values. 
+These widgets are used for manipulating process variable values.
 
 ### Sliders
 
@@ -27,11 +27,13 @@ from lume_epics.client.widgets.controls import build_sliders
 prefix = "test"
 variable_filename = "examples/variables.pickle"
 
-# set up controller
-controller = Controller("ca")
-
 # load variables
 input_variables, output_variables = load_variables(variable_filename)
+
+# set up controller
+controller = Controller("ca", input_variables, output_variables, prefix)
+
+# convert ot list for slider use
 input_variables = list(input_variable.values())
 
 # build sliders
@@ -48,7 +50,7 @@ for slider in sliders:
 ```
 ### Entry table
 
-The entry table is used for single value updates to process variables. Bulk modification can also be submitted using the entry table. The table is composed of labels and entry fields. The entry table is also packaged with a clear button, for clearing the entered values from the fields, and a submit button for sending the values to the process variables. 
+The entry table is used for single value updates to process variables. Bulk modification can also be submitted using the entry table. The table is composed of labels and entry fields. The entry table is also packaged with a clear button, for clearing the entered values from the fields, and a submit button for sending the values to the process variables.
 
 
 ```python
@@ -64,11 +66,13 @@ from lume_epics.client.widgets.controls import EntryTable
 prefix = "test"
 variable_filename = "examples/variables.pickle"
 
-# set up controller
-controller = Controller("ca")
-
 # load variables
 input_variables, output_variables = load_variables(variable_filename)
+
+# set up controller
+controller = Controller("ca", input_variables, output_variables, prefix)
+
+# conver to list for use with table
 input_variables = list(input_variable.values())
 
 # build entry table
@@ -104,7 +108,7 @@ variable_filename = "examples/variables.pickle"
 input_variables, output_variables = load_variables(variable_filename)
 
 # set up controller
-controller = Controller("ca")
+controller = Controller("ca", input_variables, output_variables, prefix)
 
 # select our image output variable to render
 image_output = [output_variables["output1"]]
@@ -146,8 +150,7 @@ variable_filename = "examples/variables.pickle"
 input_variables, output_variables = load_variables(variable_filename)
 
 # set up controller
-controller = Controller("ca")
-
+controller = Controller("ca", input_variables, output_variables, prefix)
 
 striptool = Striptool([output_variables["output2"], output_variables["output3"]], controller, prefix)
 
@@ -182,8 +185,7 @@ variable_filename = "examples/variables.pickle"
 input_variables, output_variables = load_variables(variable_filename)
 
 # set up controller
-controller = Controller("ca")
-
+controller = Controller("ca", input_variables, output_variables, prefix)
 
 value_table = ValueTable([output_variables["output2"], output_variables["output3"]], controller, prefix)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # lume-epics
-Lume-epics is a dedicated API for serving LUME model variables with EPICS. 
+Lume-epics is a dedicated API for serving LUME model variables with EPICS.
 
 ## Model Development
 
@@ -15,7 +15,7 @@ def model(input_1, input_2):
 
 ### Defining input and output variables
 
-Model input and output variables are represented by [lume-model](https://github.com/slaclab/lume-model) variable representations. These variables enforce the minimal data requirements necessary for serving EPICS process variables associated with an online model. Lume-model defines two variable types: scalar and image. Each type has both an associated input and output class. Scalar variables hold float values while image variables hold two dimensional arrays. 
+Model input and output variables are represented by [lume-model](https://github.com/slaclab/lume-model) variable representations. These variables enforce the minimal data requirements necessary for serving EPICS process variables associated with an online model. Lume-model defines two variable types: scalar and image. Each type has both an associated input and output class. Scalar variables hold float values while image variables hold two dimensional arrays.
 
 In order to appropriately interface with the EPICS server, scalar input variables must be assigned a range and default. When started, the server uses these defaults to execute the model and serve output variables based on the default execution. The range limits correspond the the low and high limits for EPICS graphics displays. During model execution, the current value of the variable is stored using the `value` attribute.
 
@@ -24,14 +24,14 @@ For our model, we must define two scalar input variables and one scalar output v
 from lume_model.variables import ScalarInputVariable, ScalarOutputVariable
 
 input_1 = ScalarInputVariable(
-    name="input_1", 
-    default=1.0, 
+    name="input_1",
+    default=1.0,
     range=[0, 256]
 )
 
 input_2 = ScalarInputVariable(
-    name="input_2", 
-    default=2.0, 
+    name="input_2",
+    default=2.0,
     range=[0, 256]
 )
 
@@ -51,7 +51,7 @@ class ExampleModel(SurrogateModel):
     def __init__(self, input_variables = [], output_variables = []):
         self.input_variables = input_variables
         self.output_variables = output_variables
-    
+
     def evaluate(self, input_variables):
         self.input_variables = {input_variable.name: input_variable for input_variable in input_variables}
         self.output_variables["output"].value = np.random.uniform(
@@ -62,7 +62,7 @@ class ExampleModel(SurrogateModel):
 
 ### Setting up the server
 
-We can now use the EPICS server to serve our model. The EPICS server requires an instantiated model with `input_variables` and `output_variables` defined as attributes, and a prefix for intantiation. By default, the server uses both the pvAccess and Channel Access protocols when serving the EPICS process variables. An optional keyword argument allows the server to be started using a single protocol (`protocols=["pva"]` for pvAccess, `protocols=["ca"]` for Channel Access). Once instantiated, the server is started using the `Server.start()` method, which has an optional monitor keyword argument, `monitor`, that controls thread execution. When `monitor=True`, the server is run in the main thread and may be stopped using keyboard interrupt (`Ctr+C`). If using `monitor=False`, the server can be stopped manually using the `Server.stop()` method. 
+We can now use the EPICS server to serve our model. The EPICS server requires an instantiated model with `input_variables` and `output_variables` defined as attributes, and a prefix for intantiation. By default, the server uses both the pvAccess and Channel Access protocols when serving the EPICS process variables. An optional keyword argument allows the server to be started using a single protocol (`protocols=["pva"]` for pvAccess, `protocols=["ca"]` for Channel Access). Once instantiated, the server is started using the `Server.start()` method, which has an optional monitor keyword argument, `monitor`, that controls thread execution. When `monitor=True`, the server is run in the main thread and may be stopped using keyboard interrupt (`Ctr+C`). If using `monitor=False`, the server can be stopped manually using the `Server.stop()` method.
 
 The input variables and output variables must be passed in the `model_kwargs` keyword argument because the model class accepts them in its `__init__` method. Arbitrary data may also be passed to the model with this approach.
 
@@ -96,7 +96,7 @@ server = Server(
             model_kwargs = {"input_variables": input_variables, "output_variables": output_variables}
         )
 
-# monitor = False does not loop in main thread and can be terminated 
+# monitor = False does not loop in main thread and can be terminated
 # with server.stop()
 server.start(monitor=True)
 # Runs until keyboard interrupt.
@@ -108,7 +108,7 @@ A number of EPICS compatable widgets are included in `lume-epics`. Each widget a
 
 The controller fetches variables using a configurable protocol defined on instantiation. Variable assigment is done over both pvAccess and Channel Access protocols by default. The controller must be configured to reflect the corresponding server. If using a single protocol for serving, the controller must be set up to fetch using that protocol and the excluded protocol must be disabled manually using the appropriate `set_pva=False`, `set_ca=False` key word argument. The prefix used for serving must match the prefix used with the client.
 
-For our client, we will load our saved variables and create a set of sliders for our inputs and a value table displaying the output variable. This code should be in a separate script from the server setup named `client.py`.  
+For our client, we will load our saved variables and create a set of sliders for our inputs and a value table displaying the output variable. This code should be in a separate script from the server setup named `client.py`.
 
 ```python
 from lume_model.utils import load_variables
@@ -121,19 +121,19 @@ input_variables, output_variables = load_variables("example_variables.pickle")
 prefix = "test"
 
 # initialize controller to use pvAccess for variable gets
-controller = Controller("pva")
+controller = Controller("pva", input_variables, output_variables, prefix)
 
 # build sliders for the command process variable database
 sliders = build_sliders(
             [input_variables["input_1"], input_variables["input_2"]],
-            controller, 
+            controller,
             prefix
         )
 
 # build value table
 value_table = ValueTable(
-                [output_variables["output"]], 
-                controller, 
+                [output_variables["output"]],
+                controller,
                 prefix
 )
 ```
@@ -152,7 +152,7 @@ curdoc().title = "Demo App"
 curdoc().add_root(
             row(
                 column(bokeh_sliders, width=350), column(value_table.table)
-                ) 
+                )
     )
 
 curdoc().add_periodic_callback(value_table.update, 250)
@@ -199,26 +199,26 @@ class ExampleModel(SurrogateModel):
 
 input_variables = {
     "input1": ScalarInputVariable(
-        name="input1", 
-        value=1, 
-        default=1, 
+        name="input1",
+        value=1,
+        default=1,
         range=[0, 256]
     ),
     "input2": ScalarInputVariable(
-        name="input2", 
-        value=2, 
-        default=2, 
+        name="input2",
+        value=2,
+        default=2,
         range=[0, 256]),
 }
 
 output_variables = {
     "output1": ImageOutputVariable(
-        name="output1", 
-        axis_labels=["value_1", "value_2"], 
-        axis_units=["mm", "mm"], 
-        x_min=0, 
-        x_max=50, 
-        y_min=0, 
+        name="output1",
+        axis_labels=["value_1", "value_2"],
+        axis_units=["mm", "mm"],
+        x_min=0,
+        x_max=50,
+        y_min=0,
         y_max=50
     )
 }
@@ -231,12 +231,12 @@ save_variables(input_variables, output_variables, "example_variables.pickle")
 
 prefix = "test"
 server = Server(
-            ExampleModel, 
+            ExampleModel,
             prefix,
             model_kwargs = {"input_variables": input_variables, "output_variables": output_variables}
         )
 
-# monitor = False does not loop in main thread and can be terminated 
+# monitor = False does not loop in main thread and can be terminated
 # with server.stop()
 server.start(monitor=True)
 # Runs until keyboard interrupt.
@@ -269,19 +269,19 @@ y_max = ScalarOutputVariable(
         )
 
 image_output = ImageOutputVariable(
-    name="image_output", 
-    axis_labels=["value_1", "value_2"], 
-    axis_units=["mm", "mm"], 
+    name="image_output",
+    axis_labels=["value_1", "value_2"],
+    axis_units=["mm", "mm"],
     x_min_variable="x_min",
-    x_max_variable="x_max", 
-    y_min_variable="y_min", 
+    x_max_variable="x_max",
+    y_min_variable="y_min",
     y_max_variable="y_max"
 )
 ```
 
 ### Serving from configuration files
 
-The model may be served using the variable configuration files as defined in [lume-epics](https://slaclab.github.io/lume-model/#configuration-files). Additionally, a display may be autogenerated from the same configuration file. These commands are registered as entrypoints. 
+The model may be served using the variable configuration files as defined in [lume-epics](https://slaclab.github.io/lume-model/#configuration-files). Additionally, a display may be autogenerated from the same configuration file. These commands are registered as entrypoints.
 
 After installing lume-epics, the server can be launched by:
 
@@ -309,7 +309,7 @@ Additional arguments include the number of steps to show using the striptool and
 $ render-from-template examples/files/iris_config.yml {PROTOCOL} {PREFIX} --striptool-limit 50 --ncol-widgets 5
 ```
 
-Rendering in read-only mode will hide all entry controls and render a striptool for each of the variables. 
+Rendering in read-only mode will hide all entry controls and render a striptool for each of the variables.
 
 ```
 $ render-from-template examples/files/iris_config.yml {PROTOCOL} {PREFIX} --striptool-limit 50 --ncol-widgets 5 --read-only

--- a/examples/client.py
+++ b/examples/client.py
@@ -20,15 +20,17 @@ with open("examples/files/demo_config.yml", "r") as f:
 input_variable_names = [f"{prefix}:{input_var}" for input_var in input_variables]
 output_variable_names = [f"{prefix}:{output_var}" for output_var in input_variables]
 
-# use all input variables for slider
-# prepare as list for rendering
-input_variables = list(input_variables.values())
+
 
 # select our image output variable to render
 image_output = [output_variables["output1"]]
 
 # set up controller
-controller = Controller("ca", input_variable_names, output_variable_names)  # can also use channel access
+controller = Controller("ca", input_variables, output_variables, prefix)  # can also use channel access
+
+# use all input variables for slider
+# prepare as list for rendering
+input_variables = list(input_variables.values())
 
 # build sliders
 sliders = build_sliders(input_variables, controller, prefix)

--- a/lume_epics/client/controller.py
+++ b/lume_epics/client/controller.py
@@ -61,7 +61,7 @@ class Controller:
 
     """
 
-    def __init__(self, protocol: str, input_pvs: List[str], output_pvs: List[str]):
+    def __init__(self, protocol: str, input_pvs: dict, output_pvs: dict, prefix):
         """
         Initializes controller. Stores protocol and creates context attribute if 
         using pvAccess.
@@ -86,6 +86,13 @@ class Controller:
         self._context = None
         if self._protocol == "pva":
             self._context = Context("pva")
+
+
+        for variable in {**input_pvs, **output_pvs}.values():
+            if variable.variable_type == "image":
+                self.get_image(f"{prefix}:{variable.name}")
+            else:
+                self.get_value(f"{prefix}:{variable.name}")
 
 
     def _ca_value_callback(self, pvname, value, *args, **kwargs):
@@ -184,7 +191,7 @@ class Controller:
         """Gets scalar value of a process variable.
 
         Args:
-            pvname (str): Image process variable name.
+            pvname (str): Process variable name.
 
         """
         value = self.get(pvname)

--- a/lume_epics/tests/conftest.py
+++ b/lume_epics/tests/conftest.py
@@ -19,38 +19,41 @@ package_path = abspath(dirname(dirname(__file__)))
 sys.path.insert(0, package_path)
 
 PVA_CONFIG = {
-'EPICS_PVAS_AUTO_BEACON_ADDR_LIST': 'NO', 
-'EPICS_PVAS_BEACON_ADDR_LIST': '127.0.0.1', 
-'EPICS_PVAS_BEACON_PERIOD': '15', 
-'EPICS_PVAS_BROADCAST_PORT': '60858', 
-'EPICS_PVAS_INTF_ADDR_LIST': '127.0.0.1:0', 
-'EPICS_PVAS_MAX_ARRAY_BYTES': '16384', 
-'EPICS_PVAS_PROVIDER_NAMES': '3a7aff4f-8fd4-4f9f-b696-bd9f5f6f13ed', 
-'EPICS_PVAS_SERVER_PORT': '61192', 
-'EPICS_PVA_ADDR_LIST': '127.0.0.1', 
-'EPICS_PVA_AUTO_ADDR_LIST': 'NO', 
-'EPICS_PVA_BEACON_PERIOD': '15', 
-'EPICS_PVA_BROADCAST_PORT': '60858', 
-'EPICS_PVA_MAX_ARRAY_BYTES': '16384', 
-'EPICS_PVA_SERVER_PORT': '61192'
+    "EPICS_PVAS_AUTO_BEACON_ADDR_LIST": "NO",
+    "EPICS_PVAS_BEACON_ADDR_LIST": "127.0.0.1",
+    "EPICS_PVAS_BEACON_PERIOD": "15",
+    "EPICS_PVAS_BROADCAST_PORT": "60858",
+    "EPICS_PVAS_INTF_ADDR_LIST": "127.0.0.1:0",
+    "EPICS_PVAS_MAX_ARRAY_BYTES": "16384",
+    "EPICS_PVAS_PROVIDER_NAMES": "3a7aff4f-8fd4-4f9f-b696-bd9f5f6f13ed",
+    "EPICS_PVAS_SERVER_PORT": "61192",
+    "EPICS_PVA_ADDR_LIST": "127.0.0.1",
+    "EPICS_PVA_AUTO_ADDR_LIST": "NO",
+    "EPICS_PVA_BEACON_PERIOD": "15",
+    "EPICS_PVA_BROADCAST_PORT": "60858",
+    "EPICS_PVA_MAX_ARRAY_BYTES": "16384",
+    "EPICS_PVA_SERVER_PORT": "61192",
 }
 os.environ.update(PVA_CONFIG)
 
-os.environ["PYEPICS_LIBCA"] = get_lib('ca')
+os.environ["PYEPICS_LIBCA"] = get_lib("ca")
+
 
 @pytest.fixture(scope="session", autouse=True)
 def rootdir():
     package_path = abspath(dirname(dirname(dirname(__file__))))
     return package_path
 
+
 def clear_loggers():
     """
     Remove handlers from all loggers
     """
     import logging
+
     loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
     for logger in loggers:
-        handlers = getattr(logger, 'handlers', [])
+        handlers = getattr(logger, "handlers", [])
         for handler in handlers:
             logger.removeHandler(handler)
 
@@ -78,13 +81,11 @@ def server():
     env["PYTHONPATH"] = env.get("PYTHONPATH", "") + f":{rootdir}"
 
     ca_proc = subprocess.Popen(
-            [
-                sys.executable, "launch_server.py"
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd= os.path.dirname(os.path.realpath(__file__)),
-            env=env
+        [sys.executable, "launch_server.py"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.path.dirname(os.path.realpath(__file__)),
+        env=env,
     )
 
     time.sleep(2)
@@ -92,7 +93,7 @@ def server():
     # Check it started successfully
     assert not ca_proc.poll()
 
-    #yield ca_proc
+    # yield ca_proc
     yield ca_proc
 
     # teardown
@@ -108,13 +109,17 @@ def model():
 def prefix():
     yield "test"
 
+
 @pytest.fixture(scope="session", autouse=True)
 def protocol():
     yield "ca"
 
+
 @pytest.fixture(scope="session", autouse=True)
 def controller(prefix, protocol, model):
-    controller = Controller(protocol, [f"{prefix}:{pv}" for pv in model.input_variables], [f"{prefix}:{pv}" for pv in model.output_variables])
+    controller = Controller(
+        protocol, model.input_variables, model.output_variables, prefix
+    )
 
     yield controller
 

--- a/lume_epics/tests/widgets/test_entry_table.py
+++ b/lume_epics/tests/widgets/test_entry_table.py
@@ -5,9 +5,12 @@ import time
 from lume_model.variables import ScalarInputVariable
 from lume_epics.client.widgets.controls import EntryTable
 
+
 @pytest.fixture(scope="module", autouse=True)
 def entry_inputs(model):
-    return [var for var in model.input_variables.values() if var.variable_type=="scalar"]
+    return [
+        var for var in model.input_variables.values() if var.variable_type == "scalar"
+    ]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -15,14 +18,15 @@ def entry_table(controller, prefix, entry_inputs, server):
     # create entry table
     return EntryTable(entry_inputs, controller, prefix)
 
+
 def test_entry_table_clear(entry_table, entry_inputs):
     # clear
     entry_table.clear()
     for input_var in entry_inputs:
         assert entry_table.text_inputs[input_var.name].value_input == ""
 
+
 # test entry table submit
-@pytest.mark.skip(reason="Relies on fix in controller bug.")
 @pytest.mark.parametrize("value", [(7), (3)])
 def test_entry_table_sumbit(value, entry_table, entry_inputs, prefix, server):
 
@@ -30,8 +34,6 @@ def test_entry_table_sumbit(value, entry_table, entry_inputs, prefix, server):
         entry_table.text_inputs[input_var.name].value_input = str(value)
 
     entry_table.submit()
-
-    time.sleep(1)
 
     for input_var in entry_inputs:
         if not input_var.is_constant:

--- a/lume_epics/tests/widgets/test_image_plot.py
+++ b/lume_epics/tests/widgets/test_image_plot.py
@@ -12,7 +12,9 @@ from lume_epics.client.widgets.plots import ImagePlot
 
 @pytest.fixture(scope="session")
 def image_vars(model):
-    return [var for var in model.input_variables.values() if var.variable_type == "image"]
+    return [
+        var for var in model.input_variables.values() if var.variable_type == "image"
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +40,6 @@ def test_image_plot_missing_build_params(image_plot):
     image_plot.build_plot(palette=YlGn3)
 
 
-@pytest.mark.skip(reason="Relies on fixes in controller")
 def test_image_plot_update(image_plot, image_vars, prefix, server, controller):
     updated_vals = {}
 
@@ -57,11 +58,9 @@ def test_image_plot_update(image_plot, image_vars, prefix, server, controller):
     # random dist for variable
     for var in image_vars:
         image_plot.live_variable = var.name
-        
+
         image_plot.update()
 
         val = image_plot.source.data["image"][0]
 
         assert (updated_vals[var.name] == val).all
-
-

--- a/lume_epics/tests/widgets/test_value_table.py
+++ b/lume_epics/tests/widgets/test_value_table.py
@@ -2,32 +2,41 @@ import pytest
 import epics
 from lume_epics.client.widgets.tables import ValueTable
 
+
+@pytest.fixture(scope="module")
+def input_variables(model):
+    return [
+        var for var in model.input_variables.values() if var.variable_type == "scalar"
+    ]
+
+
 @pytest.fixture(scope="module")
 def table_variables(model):
-    return [var for var in model.output_variables.values() if var.variable_type == "scalar"]
+    return [
+        var for var in model.output_variables.values() if var.variable_type == "scalar"
+    ]
+
 
 @pytest.fixture(scope="module")
 def value_table(controller, model, prefix, table_variables):
 
     return ValueTable(table_variables, controller, prefix)
 
-@pytest.mark.skip(reason="Requires controller bug fix.")
-def test_value_table_update(value_table, prefix, table_variables):
 
-    updated_vals = {}
+@pytest.mark.parametrize("value", [(1), (5), (8)])
+def test_value_table_update(
+    value, value_table, prefix, table_variables, server, input_variables
+):
 
-    for var in table_variables:
-        val_idx = value_table._source.data["x"].index(var.name)
-        val = value_table._source.data["y"][val_idx]
-
-        updated_vals[var.name] = float(val) * 2
-        epics.caput(f"{prefix}:{var.name}", float(val) * 2)
+    # update input variables to trigger output update
+    for var in input_variables:
+        epics.caput(f"{prefix}:{var.name}", value)
 
     value_table.update()
 
     for var in table_variables:
         val_idx = value_table._source.data["x"].index(var.name)
+        epics_val = epics.caget(f"{prefix}:{var.name}")
         val = value_table._source.data["y"][val_idx]
 
-        assert updated_vals[var.name] == float(val)
-    
+        assert epics_val == float(val)

--- a/lume_epics/tests/widgets/test_value_table.py
+++ b/lume_epics/tests/widgets/test_value_table.py
@@ -1,5 +1,6 @@
 import pytest
 import epics
+import time
 from lume_epics.client.widgets.tables import ValueTable
 
 
@@ -31,6 +32,8 @@ def test_value_table_update(
     # update input variables to trigger output update
     for var in input_variables:
         epics.caput(f"{prefix}:{var.name}", value)
+
+    time.sleep(1)
 
     value_table.update()
 


### PR DESCRIPTION
Controller:
New testing revealed bugs on initial initialization of image variables in the controller. Additionally, an update after construction was necessary for retrieving latest value despite an active server. 
The controller will now accept both input and output variables and initialize connections on construction.
Controllers constructed after this release will not be backwards compatible. 

Server:
Due to the implementation of constant checks on variables, updates to input image variables served using the area detector naming scheme were not being picked up. Now, the server constructs a child -> parent mapping on pvdb construction and writes will check map for inclusion.