### PR TITLE
Increment lume-model version to 0.13

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - setuptools
   run:
-    - python
+    - python >=3.6
     - epics-base
     - pyepics
     - pcaspy
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - bokeh>=2.3.3
     - click
-    - lume-model>=0.12
+    - lume-model>=0.13
     - nose>=1.1.2
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,9 +21,9 @@ requirements:
     - pcaspy
     - p4p
     - numpy
-    - bokeh
+    - bokeh>=2.3.3
     - click
-    - lume-model>=0.11
+    - lume-model>=0.12
     - nose>=1.1.2
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - pcaspy
     - p4p
     - numpy
-    - bokeh>=2.3.3
+    - bokeh
     - click
     - lume-model>=0.13
     - nose>=1.1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,5 @@ p4p
 numpy
 bokeh
 click
-lume-model>=0.11
+lume-model>=0.12
 nose>=1.1.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,5 @@ p4p
 numpy
 bokeh
 click
-lume-model>=0.12
+lume-model>=0.13
 nose>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pcaspy
 pyepics
 p4p
 numpy
-bokeh>=2.3.3
+bokeh
 click
 lume-model>=0.13
 nose>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pcaspy
 pyepics
 p4p
 numpy
-bokeh
+bokeh>=2.3.3
 click
-lume-model>=0.11
+lume-model>=0.12
 nose>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ p4p
 numpy
 bokeh>=2.3.3
 click
-lume-model>=0.12
+lume-model>=0.13
 nose>=1.1.2


### PR DESCRIPTION
This PR increments LUME-model to version 0.13, correcting a discrepancy in legacy handling of tensorflow graph/sessions.