### PR TITLE
Read only server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The dependencies for lume-epics are:
 * `python>=3.7`
 * `pydantic`
 * `pcaspy`
-* `pyepics` 
+* `pyepics`
 * `p4p`
 * `numpy`
 * `bokeh`
@@ -21,19 +21,19 @@ The dependencies for lume-epics are:
 * `EPICS >= 7.0.1`.
 
 ## Server
-The EPICS server requires a model class, input variables, output variables, and a prefix for intantiation. By default, the server uses both the pvAccess and Channel Access protocols when serving the EPICS process variables. An optional keyword argument allows the server to be started using a single protocol (`protocols=["pva"]` for pvAccess, `protocols=["ca"]` for Channel Access). Once instantiated, the server is started using the `Server.start()` method, which has an optional monitor keyword argument, `monitor`, that controls thread execution. When `monitor=True`, the server is run in the main thread and may be stopped using keyboard interrupt (`Ctr+C`). If using `monitor=False`, the server can be stopped manually using the `Server.stop()` method. 
+The EPICS server requires a model class, input variables, output variables, and a prefix for intantiation. By default, the server uses both the pvAccess and Channel Access protocols when serving the EPICS process variables. An optional keyword argument allows the server to be started using a single protocol (`protocols=["pva"]` for pvAccess, `protocols=["ca"]` for Channel Access). Once instantiated, the server is started using the `Server.start()` method, which has an optional monitor keyword argument, `monitor`, that controls thread execution. When `monitor=True`, the server is run in the main thread and may be stopped using keyboard interrupt (`Ctr+C`). If using `monitor=False`, the server can be stopped manually using the `Server.stop()` method.
 
 ```python
 from lume_epics.epics_server import Server
 
 prefix = "test"
 server = Server(
-            DemoModel, 
-            DemoModel.input_variables, 
-            DemoModel.output_variables, 
+            DemoModel,
+            DemoModel.input_variables,
+            DemoModel.output_variables,
             prefix
         )
-# monitor = False does not loop in main thread and can be terminated 
+# monitor = False does not loop in main thread and can be terminated
 # with server.stop()
 server.start(monitor=True)
 # Runs until keyboard interrupt.
@@ -41,3 +41,7 @@ server.start(monitor=True)
 
 ## Compatable models
 See docs for notes on serving online models with lume-epics.
+
+
+## LIBCA
+Issues may arise over the use of pyepics libca and the pcaspy libca from epicscorelibs. In order for the server to function, pyepics must use the pcaspy libca. This may be found using the command `find . -name "libca*"` in your environment's `site-packages`, then setting the environment variable `PYEPICS_LIBCA=/path/to/epicscorelibs/libca/file`.

--- a/docs/BokehServer.md
+++ b/docs/BokehServer.md
@@ -89,32 +89,34 @@ if __name__ == "__main__":
 
 ## Create server
 
-Create a new file named `server.py`. Import the `DemoModel`, load the variables, and configure the server.
+Create a new file named `server.py`. Import the `DemoModel`, load the variables, and configure the server. Due to the multiprocess spawning of the application, the server must run inside the main conditional of the python script.
 
 ```python
 from examples.model import DemoModel
 from lume_epics.epics_server import Server
 from lume_model.utils import load_variables
 
-variable_filename = "variables.pickle"
-input_variables, output_variables = load_variables(variable_filename)
+# Server must run in main
+if __name__ == "__main__":
+    variable_filename = "variables.pickle"
+    input_variables, output_variables = load_variables(variable_filename)
 
-# pass the input + output variable to initialize the classs
-model_kwargs = {
-    "input_variables": input_variables,
-    "output_variables": output_variables
-}
+    # pass the input + output variable to initialize the classs
+    model_kwargs = {
+        "input_variables": input_variables,
+        "output_variables": output_variables
+    }
 
-prefix = "test"
-server = Server(
-    DemoModel,
-    input_variables,
-    output_variables,
-    prefix,
-    model_kwargs=model_kwargs
-)
-# monitor = False does not loop in main thread
-server.start(monitor=True)
+    prefix = "test"
+    server = Server(
+        DemoModel,
+        input_variables,
+        output_variables,
+        prefix,
+        model_kwargs=model_kwargs
+    )
+    # monitor = False does not loop in main thread
+    server.start(monitor=True)
 ```
 
 ## Set up the client

--- a/docs/EPICS.md
+++ b/docs/EPICS.md
@@ -8,18 +8,20 @@ from examples.model import DemoModel
 from lume_epics.epics_server import Server
 from lume_model.utils import variables_from_yaml
 
-with open("examples/files/demo_config.yml", "r") as f:
-    input_variables, output_variables = variables_from_yaml(f)
+# must use main conditional due to multiprocess spawning
+if __name__ == "__main__":
+    with open("examples/files/demo_config.yml", "r") as f:
+        input_variables, output_variables = variables_from_yaml(f)
 
-prefix = "test"
-server = Server(
-    DemoModel,
-    prefix,
-    model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
-    epics_config={"EPICS_CA_SERVER_PORT": 63000, "EPICS_PVA_SERVER_PORT": 63001}
-)
-# monitor = False does not loop in main thread
-server.start(monitor=True)
+    prefix = "test"
+    server = Server(
+        DemoModel,
+        prefix,
+        model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
+        epics_config={"EPICS_CA_SERVER_PORT": 63000, "EPICS_PVA_SERVER_PORT": 63001}
+    )
+    # monitor = False does not loop in main thread
+    server.start(monitor=True)
 ```
 
 A description of the channel access variables may be found [here](https://epics.anl.gov/base/R3-14/12-docs/CAref.html#EPICS). pvAccess variables take a similar form (substituting PVA for CA).

--- a/docs/index.md
+++ b/docs/index.md
@@ -221,23 +221,25 @@ output_variables = {
     )
 }
 
-from lume_epics.epics_server import Server
-from lume_model.utils import save_variables
+# must use main for server due to multiprocess spawning
+if __name__ == "__main"__:
+    from lume_epics.epics_server import Server
+    from lume_model.utils import save_variables
 
-# save variables
-save_variables(input_variables, output_variables, "example_variables.pickle")
+    # save variables
+    save_variables(input_variables, output_variables, "example_variables.pickle")
 
-prefix = "test"
-server = Server(
-            ExampleModel,
-            prefix,
-            model_kwargs = {"input_variables": input_variables, "output_variables": output_variables}
-        )
+    prefix = "test"
+    server = Server(
+                ExampleModel,
+                prefix,
+                model_kwargs = {"input_variables": input_variables, "output_variables": output_variables}
+            )
 
-# monitor = False does not loop in main thread and can be terminated
-# with server.stop()
-server.start(monitor=True)
-# Runs until keyboard interrupt.
+    # monitor = False does not loop in main thread and can be terminated
+    # with server.stop()
+    server.start(monitor=True)
+    # Runs until keyboard interrupt.
 ```
 
 

--- a/examples/read_only/client.py
+++ b/examples/read_only/client.py
@@ -26,7 +26,7 @@ image_output = [output_variables["output1"]]
 
 # set up controller
 controller = Controller(
-    "pva", input_variables, output_variables, prefix
+    "ca", input_variables, output_variables, prefix
 )  # can also use channel access
 
 # use all input variables for slider

--- a/examples/read_only/client.py
+++ b/examples/read_only/client.py
@@ -1,0 +1,116 @@
+from bokeh.io import curdoc
+from bokeh import palettes
+from bokeh.layouts import column, row
+from bokeh.models import LinearColorMapper, Div
+
+from lume_epics.client.controller import Controller
+from lume_model.utils import variables_from_yaml
+
+from lume_epics.client.widgets.plots import ImagePlot, Striptool
+from lume_epics.client.widgets.tables import ValueTable
+from lume_epics.client.widgets.controls import build_sliders, EntryTable
+from lume_epics.client.controller import Controller
+
+prefix = "test"
+
+# load variables
+with open("examples/files/demo_config.yml", "r") as f:
+    input_variables, output_variables = variables_from_yaml(f)
+
+input_variable_names = [f"{prefix}:{input_var}" for input_var in input_variables]
+output_variable_names = [f"{prefix}:{output_var}" for output_var in input_variables]
+
+
+# select our image output variable to render
+image_output = [output_variables["output1"]]
+
+# set up controller
+controller = Controller(
+    "pva", input_variables, output_variables, prefix
+)  # can also use channel access
+
+# use all input variables for slider
+# prepare as list for rendering
+input_variables = list(input_variables.values())
+
+# build sliders
+sliders = build_sliders(input_variables, controller,)
+
+# create image plot
+pal = palettes.viridis(256)
+color_mapper = LinearColorMapper(palette=pal, low=0, high=256)
+image_plot = ImagePlot(image_output, controller, color_mapper=color_mapper)
+
+striptool = Striptool(
+    [output_variables["output2"], output_variables["output3"]], controller
+)
+
+entry_table = EntryTable(input_variables, controller)
+value_table = ValueTable(input_variables, controller)
+
+# Set up image update callback
+def image_update_callback():
+    image_plot.update()
+
+
+# set sizes
+image_plot.plot.height = 400
+image_plot.plot.width = 450
+striptool.plot.height = 400
+striptool.plot.width = 450
+
+title_div = Div(
+    text=f"<b>Demo app: Last input update {controller.last_input_update}</b>",
+    style={
+        "font-size": "150%",
+        "color": "#3881e8",
+        "text-align": "center",
+        "width": "100%",
+    },
+)
+output_update_div = Div(
+    text=f"<b>Last output update {controller.last_output_update}</b>",
+    style={
+        "font-size": "150%",
+        "color": "#3881e8",
+        "text-align": "center",
+        "width": "100%",
+    },
+)
+
+
+def update_div_text():
+    global controller
+    title_div.text = (
+        f"<b>Demo app: Last input update {controller.last_input_update}</b>"
+    )
+    output_update_div.text = (
+        f"<b>Last output update {controller.last_output_update}</b>"
+    )
+
+
+# render
+curdoc().title = "Demo App"
+curdoc().add_root(
+    column(
+        row(column(title_div, output_update_div)),
+        row(
+            column([slider.bokeh_slider for slider in sliders], width=350),
+            column(image_plot.plot),
+            column(striptool.selection, striptool.reset_button, striptool.plot),
+        ),
+        row(
+            column(
+                entry_table.table, entry_table.clear_button, entry_table.submit_button
+            ),
+            value_table.table,
+        ),
+    )
+)
+
+curdoc().add_periodic_callback(image_plot.update, 250)
+for slider in sliders:
+    curdoc().add_periodic_callback(slider.update, 250)
+curdoc().add_periodic_callback(striptool.update, 250)
+curdoc().add_periodic_callback(update_div_text, 250)
+curdoc().add_periodic_callback(value_table.update, 250)

--- a/examples/read_only/demo_ioc.db
+++ b/examples/read_only/demo_ioc.db
@@ -1,0 +1,16 @@
+record(ai, "test:input1")
+{
+   field(PINI, "YES")
+   field(VAL,  1)
+   field(PREC, 3)
+   field(HOPR, 256)
+   field(LOPR, 0)
+}
+record(ai, "test:input2")
+{
+   field(PINI, "YES")
+   field(VAL,  2)
+   field(PREC, 3)
+   field(HOPR, 256)
+   field(LOPR, 0)
+}

--- a/examples/read_only/demo_ioc.db
+++ b/examples/read_only/demo_ioc.db
@@ -3,14 +3,10 @@ record(ai, "test:input1")
    field(PINI, "YES")
    field(VAL,  1)
    field(PREC, 3)
-   field(HOPR, 256)
-   field(LOPR, 0)
 }
 record(ai, "test:input2")
 {
    field(PINI, "YES")
    field(VAL,  2)
    field(PREC, 3)
-   field(HOPR, 256)
-   field(LOPR, 0)
 }

--- a/examples/read_only/model.py
+++ b/examples/read_only/model.py
@@ -1,7 +1,12 @@
 import numpy as np
-from lume_model.variables import ScalarInputVariable, ImageOutputVariable, ScalarOutputVariable
+from lume_model.variables import (
+    ScalarInputVariable,
+    ImageOutputVariable,
+    ScalarOutputVariable,
+)
 from lume_model.models import SurrogateModel
 from lume_model.utils import save_variables
+
 
 class DemoModel(SurrogateModel):
     def __init__(self, input_variables=None, output_variables=None):
@@ -11,9 +16,9 @@ class DemoModel(SurrogateModel):
     def evaluate(self, input_variables):
         input_variables = {input_var.name: input_var for input_var in input_variables}
         self.output_variables["output1"].value = np.random.uniform(
-            input_variables["input1"].value, # lower dist bound
-            input_variables["input2"].value, # upper dist bound
-            (50,50)
+            input_variables["input1"].value,  # lower dist bound
+            input_variables["input2"].value,  # upper dist bound
+            (50, 50),
         )
         self.output_variables["output2"].value = input_variables["input1"].value
         self.output_variables["output3"].value = input_variables["input2"].value

--- a/examples/read_only/model.py
+++ b/examples/read_only/model.py
@@ -1,0 +1,21 @@
+import numpy as np
+from lume_model.variables import ScalarInputVariable, ImageOutputVariable, ScalarOutputVariable
+from lume_model.models import SurrogateModel
+from lume_model.utils import save_variables
+
+class DemoModel(SurrogateModel):
+    def __init__(self, input_variables=None, output_variables=None):
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+
+    def evaluate(self, input_variables):
+        input_variables = {input_var.name: input_var for input_var in input_variables}
+        self.output_variables["output1"].value = np.random.uniform(
+            input_variables["input1"].value, # lower dist bound
+            input_variables["input2"].value, # upper dist bound
+            (50,50)
+        )
+        self.output_variables["output2"].value = input_variables["input1"].value
+        self.output_variables["output3"].value = input_variables["input2"].value
+
+        return list(self.output_variables.values())

--- a/examples/read_only/server.py
+++ b/examples/read_only/server.py
@@ -1,0 +1,20 @@
+from lume_epics.epics_server import Server
+from lume_model.utils import variables_from_yaml
+import os
+os.environ["PTYHONPATH"] = "/Users/jgarra/sandbox/lume-epics"
+from examples.model import DemoModel
+
+with open("examples/files/demo_config.yml", "r") as f:
+    input_variables, output_variables = variables_from_yaml(f)
+
+prefix = "test"
+server = Server(
+    DemoModel,
+    prefix,
+    model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
+    read_only=True,
+    protocols=["pva"]
+
+)
+# monitor = False does not loop in main thread
+server.start(monitor=True)

--- a/examples/read_only/server.py
+++ b/examples/read_only/server.py
@@ -1,23 +1,25 @@
 from lume_epics.epics_server import Server
 from lume_model.utils import variables_from_yaml
 import os
-
-os.environ["PTYHONPATH"] = "/Users/jgarra/sandbox/lume-epics"
 from examples.model import DemoModel
 
-with open("examples/files/demo_config.yml", "r") as f:
-    input_variables, output_variables = variables_from_yaml(f)
+import logging
 
-prefix = "test"
-server = Server(
-    DemoModel,
-    prefix,
-    model_kwargs={
-        "input_variables": input_variables,
-        "output_variables": output_variables,
-    },
-    read_only=True,
-    protocols=["pva"],
-)
-# monitor = False does not loop in main thread
-server.start(monitor=True)
+
+if __name__ == "__main__":
+    with open("examples/files/demo_config.yml", "r") as f:
+        input_variables, output_variables = variables_from_yaml(f)
+
+    prefix = "test"
+    server = Server(
+        DemoModel,
+        prefix,
+        model_kwargs={
+            "input_variables": input_variables,
+            "output_variables": output_variables,
+        },
+        read_only=True,
+        protocols=["ca"],
+    )
+    # monitor = False does not loop in main thread
+    server.start(monitor=True)

--- a/examples/read_only/server.py
+++ b/examples/read_only/server.py
@@ -1,6 +1,7 @@
 from lume_epics.epics_server import Server
 from lume_model.utils import variables_from_yaml
 import os
+
 os.environ["PTYHONPATH"] = "/Users/jgarra/sandbox/lume-epics"
 from examples.model import DemoModel
 
@@ -11,10 +12,12 @@ prefix = "test"
 server = Server(
     DemoModel,
     prefix,
-    model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
+    model_kwargs={
+        "input_variables": input_variables,
+        "output_variables": output_variables,
+    },
     read_only=True,
-    protocols=["pva"]
-
+    protocols=["pva"],
 )
 # monitor = False does not loop in main thread
 server.start(monitor=True)

--- a/examples/server.py
+++ b/examples/server.py
@@ -6,10 +6,15 @@ with open("examples/files/demo_config.yml", "r") as f:
     input_variables, output_variables = variables_from_yaml(f)
 
 prefix = "test"
-server = Server(
-    DemoModel,
-    prefix,
-    model_kwargs={"input_variables": input_variables, "output_variables": output_variables},
-)
-# monitor = False does not loop in main thread
-server.start(monitor=True)
+
+if __name__ == "__main__":
+    server = Server(
+        DemoModel,
+        prefix,
+        model_kwargs={
+            "input_variables": input_variables,
+            "output_variables": output_variables,
+        },
+    )
+    # monitor = False does not loop in main thread
+    server.start(monitor=True)

--- a/lume_epics/epics_ca_server.py
+++ b/lume_epics/epics_ca_server.py
@@ -6,19 +6,24 @@ import signal
 from typing import Dict
 from lume_model.variables import Variable, InputVariable, OutputVariable
 import numpy as np
-from pcaspy import Driver, SimpleServer
+
+import os
+from queue import Full, Empty, Queue
+
 from epics import caget
 from epics.ca import CAThread
 import epics
-import os
-import pcaspy
 from epics import camonitor
-from queue import Full, Empty, Queue
 from epics.multiproc import CAProcess
+
+# initialize libca before pcaspy import
+if not epics.ca.libca:
+    epics.ca.initialize_libca()
+
+import pcaspy
+from pcaspy import Driver, SimpleServer
 from typing import Dict, Mapping, Union, List
 from functools import partial
-
-# os.environ["PYEPICS_LIBCA"] = "/Users/jgarra/opt/anaconda3/envs/lume-epics/epics/lib/darwin-x86/libca.dylib"
 
 
 # Each server must have their outQueue in which the comm server will set the inputs and outputs vars to be updated
@@ -31,12 +36,6 @@ logger = logging.getLogger(__name__)
 class CAServerThread(CAThread):
     """
     A helper class to run server in a thread.
-    The following snippet runs the server for 4 seconds and quit::
-        server = SimpleServer()
-        server_thread = ServerThread(server)
-        server_thread.start()
-        time.sleep(4)
-        server_thread.stop()
     """
 
     def __init__(self, server):

--- a/lume_epics/epics_pva_server.py
+++ b/lume_epics/epics_pva_server.py
@@ -318,7 +318,8 @@ class PVAServer(multiprocessing.Process):
                 time.sleep(0.1)
                 logger.debug("out queue empty")
 
-        self._context.close()
+        if self._read_only:
+            self._context.close()
         self.pva_server.stop()
         logger.info("pvAccess server stopped.")
 

--- a/lume_epics/epics_server.py
+++ b/lume_epics/epics_server.py
@@ -1,6 +1,12 @@
 import time
 import logging
 import multiprocessing
+
+try:
+    multiprocessing.set_start_method("spawn")
+except:
+    pass
+
 import os
 from typing import Dict, Mapping, Union, List
 from threading import Thread
@@ -20,8 +26,6 @@ from .epics_ca_server import CAServer
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-# multiprocessing.set_start_method("spawn")
 
 
 class Server:

--- a/lume_epics/epics_server.py
+++ b/lume_epics/epics_server.py
@@ -21,6 +21,8 @@ from .epics_ca_server import CAServer
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+multiprocessing.set_start_method("spawn")
+
 
 class Server:
     """

--- a/lume_epics/epics_server.py
+++ b/lume_epics/epics_server.py
@@ -85,6 +85,11 @@ class Server:
                 '(pvAccess) and "ca" (Channel Access).'
             )
 
+        if read_only and len(protocols) > 1:
+            raise ValueError(
+                "Only single protocol may be provided for read-only server."
+            )
+
         # Update epics configuration
         for var in EPICS_ENV_VARS:
             if epics_config.get(var):

--- a/lume_epics/epics_server.py
+++ b/lume_epics/epics_server.py
@@ -21,7 +21,7 @@ from .epics_ca_server import CAServer
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-multiprocessing.set_start_method("spawn")
+# multiprocessing.set_start_method("spawn")
 
 
 class Server:
@@ -173,8 +173,11 @@ class Server:
             )
 
             # add callback to monitors
-            for var in self.input_variables:
-                self._ca_monitors[var].add_callback(self.ca_process._monitor_callback)
+            if self._read_only:
+                for var in self.input_variables:
+                    self._ca_monitors[var].add_callback(
+                        self.ca_process._monitor_callback
+                    )
 
         # initialize pvAccess server
         if "pva" in protocols:

--- a/lume_epics/tests/conftest.py
+++ b/lume_epics/tests/conftest.py
@@ -19,20 +19,9 @@ package_path = abspath(dirname(dirname(__file__)))
 sys.path.insert(0, package_path)
 
 PVA_CONFIG = {
-    "EPICS_PVAS_AUTO_BEACON_ADDR_LIST": "NO",
-    "EPICS_PVAS_BEACON_ADDR_LIST": "127.0.0.1",
-    "EPICS_PVAS_BEACON_PERIOD": "15",
-    "EPICS_PVAS_BROADCAST_PORT": "60858",
-    "EPICS_PVAS_INTF_ADDR_LIST": "127.0.0.1:0",
-    "EPICS_PVAS_MAX_ARRAY_BYTES": "16384",
-    "EPICS_PVAS_PROVIDER_NAMES": "3a7aff4f-8fd4-4f9f-b696-bd9f5f6f13ed",
-    "EPICS_PVAS_SERVER_PORT": "61192",
     "EPICS_PVA_ADDR_LIST": "127.0.0.1",
     "EPICS_PVA_AUTO_ADDR_LIST": "NO",
-    "EPICS_PVA_BEACON_PERIOD": "15",
     "EPICS_PVA_BROADCAST_PORT": "60858",
-    "EPICS_PVA_MAX_ARRAY_BYTES": "16384",
-    "EPICS_PVA_SERVER_PORT": "61192",
 }
 os.environ.update(PVA_CONFIG)
 

--- a/lume_epics/tests/launch_server.py
+++ b/lume_epics/tests/launch_server.py
@@ -1,4 +1,3 @@
-import subprocess
 import numpy as np
 import os
 import logging

--- a/lume_epics/tests/test_controller.py
+++ b/lume_epics/tests/test_controller.py
@@ -11,7 +11,7 @@ def image_variables(model):
     ]
 
 
-@pytest.mark.skip(reason="Skip until pytest-ordering is compatable with 3.8")
+# @pytest.mark.skip(reason="Skip until pytest-ordering is compatable with 3.8")
 # @pytest.mark.last
 @pytest.mark.parametrize("x_min,x_max,y_min,y_max", [(0, 10, 0, 5), (5, 10, 4, 5)])
 def test_controller_image_update_ca(

--- a/lume_epics/tests/test_server.py
+++ b/lume_epics/tests/test_server.py
@@ -23,7 +23,7 @@ from lume_epics.tests.conftest import PVA_CONFIG
 @pytest.mark.parametrize("value", [(1.0)])
 def test_constant_variable_ca(value, prefix, server, model):
 
-    os.environ["PYEPICS_LIBCA"] = get_lib('ca')
+    os.environ["PYEPICS_LIBCA"] = get_lib("ca")
 
     # check constant variable assignment
     for _, variable in model.input_variables.items():
@@ -42,15 +42,18 @@ def test_constant_variable_ca(value, prefix, server, model):
             else:
                 assert val == value
 
-@pytest.mark.skip(reason="Occasional undiagnosed failure with pvAccess server...")
+
+@pytest.mark.skip(
+    reason="pvAccess server requires spawn method disrupted by subprocess popen..."
+)
 @pytest.mark.parametrize("value", [(1.0)])
 def test_constant_variable_pva(value, prefix, server, model):
-    ctxt = Context("pva", conf=PVA_CONFIG, maxsize=2)
+    ctxt = Context("pva", conf=PVA_CONFIG)
 
-    #check constant variable assignment
+    # check constant variable assignment
     for _, variable in model.input_variables.items():
         pvname = f"{prefix}:{variable.name}"
-            
+
         if variable.variable_type == "scalar":
 
             count = 3
@@ -89,7 +92,7 @@ def test_constant_variable_pva(value, prefix, server, model):
                     ctxt = Context("pva", conf=PVA_CONFIG)
                     time.sleep(1)
                     count -= 1
-            
+
             if count == 0:
                 raise Exception("Failed gets.")
 


### PR DESCRIPTION
This PR implements a read_only setting propagated to both the Channel Access and PVAccess servers. Instead of serving, monitors and callbacks are introduced for changes to process variables.